### PR TITLE
Add unit test for Ring wrap-around

### DIFF
--- a/DailyLockTests/RingTests.swift
+++ b/DailyLockTests/RingTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import DailyLock
+
+@Suite("Ring Tests")
+struct RingTests {
+    @Test("item(before:) wraps to last when called on first element")
+    func itemBeforeWraps() {
+        let ring = Ring([1, 2, 3])
+        #expect(ring.item(before: 1) == 3)
+        #expect(ring.item(before: 2) == 1)
+    }
+
+    @Test("item(after:) wraps to first when called on last element")
+    func itemAfterWraps() {
+        let ring = Ring([1, 2, 3])
+        #expect(ring.item(after: 3) == 1)
+        #expect(ring.item(after: 2) == 3)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Ring to verify wrap-around behavior of item(before:) and item(after:)

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a2612a21d08325b3951bb8c5db0083