### PR TITLE
test: add invalid date components test

### DIFF
--- a/DailyLockTests/DateExtensionTests.swift
+++ b/DailyLockTests/DateExtensionTests.swift
@@ -31,4 +31,10 @@ struct DateExtensionTests {
     func testCurrentYear() async throws {
         #expect(Date.currentYear == "2025", "Year string should be '2025'")
     }
+
+    @Test("Initializer returns nil for invalid date components")
+    func testInvalidDateComponents() async throws {
+        let invalidDate = Date(year: 2025, month: 13, day: 1)
+        #expect(invalidDate == nil, "Month 13 should produce nil")
+    }
 }


### PR DESCRIPTION
## Summary
- add unit test ensuring Date initializer returns nil for invalid components

## Testing
- `xcodebuild test -project DailyLock.xcodeproj -scheme DailyLock` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a269a2878c832584068f64e54576f0